### PR TITLE
Bump 0.2.4

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ Steps to reproduce the behavior:
 1. Set `...` as burry keyword
 2. Enable `...` options
 3. Open the following URL  
-  https://www.bing.com/search?q=copilot
+  https://...
 4. See error
 
 **Expected behavior**
@@ -26,8 +26,8 @@ If applicable, add screenshots to help explain your problem.
 
 **Environment**
 - OS: [e.g. Windows 11 Pro]
-- Browser: [e.g. Google Chrome 124.0.6367.61 (Official Build) (64-bit)]
-- Version of this extension [e.g. 0.2.0]
+- Browser: [e.g. Google Chrome 124.0.6367.156 (Official Build) (64-bit)]
+- Version of this extension: [e.g. 0.2.4]
 
 **Additional context**
 Add any other context about the problem here.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you can try a development version, the following steps are needed.
     - Tab title masking
   - The following HTML elements are not supported:
     - HTML Canvas
-    - Inside of `contentEditable` element  
+    - TextArea
   - Web Terminal based on Xterm.js:  
     see [here](./docs/BLUR_ON_XTERMJS.md)
   - Web Editor based on CodeMirror:  
@@ -80,9 +80,13 @@ If you can try a development version, the following steps are needed.
 
 ## [0.2.4](https://github.com/horihiro/TextBlurrer-ChromeExtension/releases/tag/0.2.4)
 
+  - New features
+    - Support `contentEditable`-enabled elements
   - Bug fixes
     - Fix tab title masking ([#65](https://github.com/horihiro/TextBlurrer-ChromeExtension/issues/65))
     - Fix issue with matching empty string ([#67](https://github.com/horihiro/TextBlurrer-ChromeExtension/issues/67))
+  - Chores
+    - Add documentation about priority of the keywords/patterns
 
 ## [0.2.3](https://github.com/horihiro/TextBlurrer-ChromeExtension/releases/tag/0.2.3)
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ If you can try a development version, the following steps are needed.
   - Web Editor based on CodeMirror:  
     CodeMirror, which bases GitHub code editor, repairs its own contents automatically after blurring by this extension. Then blurring and repairing are repeated, it causes infinity loop. ([#62](https://github.com/horihiro/TextBlurrer-ChromeExtension/issues/62))
 
+    > [!NOTE]
+    > Not limited to CodeMirror, it's possible that an infinity loop and a site freezing happen caused by repeat of blurring and DOM tree keeping when the extension tries to blur text on a site composited by frameworks or components which try to keep DOM tree. 
+    > As long as I investigate, lexical is also such a component.
+
 # Dependencies
   - **[jsdiff](https://github.com/kpdecker/jsdiff)**: A JavaScript text differencing implementation (BSD 3-Clause License).
 
@@ -78,6 +82,7 @@ If you can try a development version, the following steps are needed.
 
   - Bug fixes
     - Fix tab title masking ([#65](https://github.com/horihiro/TextBlurrer-ChromeExtension/issues/65))
+    - Fix issue with matching empty string ([#67](https://github.com/horihiro/TextBlurrer-ChromeExtension/issues/67))
 
 ## [0.2.3](https://github.com/horihiro/TextBlurrer-ChromeExtension/releases/tag/0.2.3)
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ If you can try a development version, the following steps are needed.
 
 # Change logs
 
+## [0.2.4](https://github.com/horihiro/TextBlurrer-ChromeExtension/releases/tag/0.2.4)
+
+  - Bug fixes
+    - Fix tab title masking ([#65](https://github.com/horihiro/TextBlurrer-ChromeExtension/issues/65))
+
 ## [0.2.3](https://github.com/horihiro/TextBlurrer-ChromeExtension/releases/tag/0.2.3)
 
   - Bug fixes

--- a/content/js/main.js
+++ b/content/js/main.js
@@ -233,7 +233,7 @@
         if (from.node == to.node) {
           const computedStyle = getComputedStyle(from.node.parentNode);
           const size = Math.floor(parseFloat(computedStyle.fontSize) / 4);
-          if (from.node.textContent === match.keyword && computedStyle.filter === 'none') {
+          if (from.node.textContent === match.keyword && from.node.parentNode.childNodes.length == 1 && computedStyle.filter === 'none') {
             from.node.parentNode.classList.add(CLASS_NAME_BLURRED);
             from.node.parentNode.classList.add(CLASS_NAME_KEEP);
             if (options?.showValue) {

--- a/content/js/main.js
+++ b/content/js/main.js
@@ -171,7 +171,7 @@
       let start = 0;
       while (true) {
         const match = contents.slice(start).match(pattern);
-        if (!match) break;
+        if (!match || match[0].length == 0) break;
         matches.push({
           keyword: match[0],
           index: start + match.index,
@@ -623,7 +623,7 @@
     const title = target.textContent;
     let result = title.match(pattern);
     let start = 0;
-    while (result) {
+    while (result && result[0].length > 0) {
       const mask = new Array(result[0].length).fill('*').join('');
       target.textContent = target.textContent.replace(result[0], mask);
       start += result.index + mask.length;

--- a/content/js/main.js
+++ b/content/js/main.js
@@ -7,7 +7,7 @@
 
   const SKIP_NODE_NAMES = ['SCRIPT', 'STYLE', 'NOSCRIPT', 'HEAD', 'META', 'LINK', 'HTML', 'TEXTAREA', 'TITLE', '#comment'];
   const BLOCK_ELEMENT_NAMES = [
-    'ADDRESS', 'ARTICLE', 'ASIDE', 'BLOCKQUOTE', 'CANVAS', 'DD', 'DIV', 'DL', 'DT', 'FIELDSET', 'FIGCAPTION',
+    'ADDRESS', 'ARTICLE', 'ASIDE', 'BLOCKQUOTE', 'BODY', 'CANVAS', 'DD', 'DIV', 'DL', 'DT', 'FIELDSET', 'FIGCAPTION',
     'FIGURE', 'FOOTER', 'FORM', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'HEADER', 'HR', 'LI', 'MAIN', 'NAV', 'NOSCRIPT',
     'OL', 'P', 'PRE', 'SCRIPT', 'SECTION', 'TABLE', 'TFOOT', 'UL', 'VIDEO'
   ];
@@ -70,10 +70,10 @@
       console.debug(`Skipped. Reason: CodeMirror`);
       return true;
     }
-    if (node.isContentEditable) {
-      console.debug(`Skipped. Reason: The node is contentEditable`);
-      return true;
-    }
+    // if (node.isContentEditable) {
+    //   console.debug(`Skipped. Reason: The node is contentEditable`);
+    //   return true;
+    // }
     return false;
   }
 
@@ -230,6 +230,7 @@
         if (!from.node.parentNode || !to.node.parentNode
           || shouldBeSkipped(from.node) || shouldBeSkipped(to.node)) return;
 
+        const currentRange = getCuretPosition(from.node);
         if (from.node == to.node) {
           const computedStyle = getComputedStyle(from.node.parentNode);
           const size = Math.floor(parseFloat(computedStyle.fontSize) / 4);
@@ -284,15 +285,21 @@
           insertNodes.push({ node: nodeAfterBlurred, refNode: to.node, target: to.node.parentNode });
           removeNodes.push(to.node);
         }
-        insertNodes.forEach((n) => {
+        insertNodes.reduce((p, n) => {
           n.target.insertBefore(n.node, n.refNode);
-          if (!isBlurred(n.node)) return;
+          if (currentRange && removeNodes.includes(currentRange.endContainer) && p + n.node.textContent.length >= currentRange.endOffset) {
+            currentRange.startOffset = currentRange.endOffset = currentRange.endOffset - p;
+            currentRange.endContainer = currentRange.startContainer = n.node.nodeName === '#text' ? n.node : Array.from(n.node.childNodes).findLast(n => n.nodeName === '#text');
+            setCuretPosition(currentRange);
+          }
+          if (!isBlurred(n.node)) return p + n.node.textContent.length;
           const node = n.node.nodeName === '#text' ? n.node.parentNode : n.node;
           options?.showValue && node.setAttribute('title', match.keyword);
           const computedStyle = getComputedStyle(node);
           const size = Math.floor(parseFloat(computedStyle.fontSize) / 4);
           if (size > 5) node.style.filter += ` blur(${size}px)`;
-        });
+          return p + n.node.textContent.length
+        }, 0);
         removeNodes.forEach((n) => {
           n.parentNode.removeChild(n);
         });
@@ -314,6 +321,7 @@
         });
       }
     }
+    target.querySelectorAll(`.${CLASS_NAME_BLURRED}`).forEach((n) => { unblurCore(n) });
     blockAndBlur(pattern, target || document.body, options);
 
     const blurInShadowRoot = (target) => {
@@ -477,7 +485,7 @@
     if (!w.__observer) {
       w.__observer = new MutationObserver((records) => {
         if (!records.some(record => {
-          return record.removedNodes.length > 0 || Array.from(record.addedNodes).some(node => {
+          return record.type === 'characterData' || record.removedNodes.length > 0 || Array.from(record.addedNodes).some(node => {
             return !['SCRIPT', 'STYLE', '#comment'].includes(node.nodeName);
           });
         })) return;
@@ -486,13 +494,18 @@
             return target.contains(record.target);
           });
           if (isContained) return targets;
+          let blockElement = record.target;
+          while (blockElement && !BLOCK_ELEMENT_NAMES.includes(blockElement.nodeName)) {
+            blockElement = blockElement.parentNode;
+          }
+          if (!blockElement) return targets;
           const array = targets.reduce((prev, target) => {
-            if (!record.target.contains(target) && target != record.target) {
+            if (!blockElement.contains(target) && target != blockElement) {
               prev.push(target)
             }
             return prev;
           }, []);
-          array.push(record.target);
+          array.push(blockElement);
           return array;
         }, []);
         w.__observer.disconnect();
@@ -578,6 +591,7 @@
       if (n.style.length == 0) n.removeAttribute('style');
       return;
     }
+    const currentRange = getCuretPosition(n);
     const p = n.parentNode;
     n.childNodes.forEach((c) => {
       if (c.nodeName !== '#text') {
@@ -596,15 +610,53 @@
           continue;
         }
         textContainer.textContent += c.textContent;
+        if (currentRange) {
+          switch (currentRange.endContainer) {
+            case c:
+              currentRange.endContainer = currentRange.startContainer = textContainer;
+              currentRange.startOffset += (textContainer.textContent.length - c.textContent.length);
+              currentRange.endOffset += (textContainer.textContent.length - c.textContent.length);
+            case textContainer:
+              setCuretPosition(currentRange);
+          }
+        }
 
         if (n.nextSibling?.nodeName === '#text') {
           n.previousSibling.textContent += n.nextSibling.textContent;
+          if (currentRange) {
+            switch (currentRange.endContainer) {
+              case n.nextSibling:
+                currentRange.endContainer = currentRange.startContainer = n.previousSibling;
+                currentRange.endOffset = currentRange.startOffset = n.previousSibling.textContent.length - n.nextSibling.textContent.length + currentRange.startOffset;
+              case n.previousSibling:
+                setCuretPosition(currentRange);
+            }
+          }
           p.removeChild(n.nextSibling);
         }
         break;
       } while (true);
     });
     p.removeChild(n);
+  };
+
+  const getCuretPosition = (target) => {
+    const selection = window.getSelection();
+    if (!target.isContentEditable && (!target.parentNode || !target.parentNode.isContentEditable) || selection.rangeCount == 0) return null;
+    return {
+      startContainer: selection.anchorNode,
+      startOffset: selection.anchorOffset,
+      endContainer: selection.focusNode,
+      endOffset: selection.focusOffset,
+    };
+  }
+  const setCuretPosition = (newRange) => {
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(newRange.startContainer, newRange.startOffset);
+    range.setEnd(newRange.endContainer, newRange.endOffset);
+    selection.removeAllRanges();
+    selection.addRange(range);
   };
 
   const unblurTabTitle = () => {

--- a/content/js/main.js
+++ b/content/js/main.js
@@ -662,7 +662,15 @@
 
   const keywords2RegExp = (keywords, mode, matchCase) => {
     return new RegExp(
-      (keywords || '').split(/\n/).filter(k => !!k.trim()).map(k => `(?:${mode === 'regexp' ? k.trim() : escapeRegExp(k.trim())})`).join('|'),
+      (keywords || '').split(/\n/)
+        .filter(k => 
+          !!k.trim() && (
+            mode !== 'regexp' ||
+            !new RegExp(k).test('')
+          )
+        )
+        .map(k => `(?:${mode === 'regexp' ? k.trim() : escapeRegExp(k.trim())})`)
+        .join('|'),
       matchCase ? '' : 'i'
     );
   };

--- a/docs/PRIORITY_OF_PATTERNS.md
+++ b/docs/PRIORITY_OF_PATTERNS.md
@@ -4,6 +4,7 @@ The matching priority of keywords/patterns depends on the order of them (i.e. th
 
 ## Example
 In this example, there is the text  `abc` in a web page. 
+
 ![image](https://github.com/horihiro/TextBlurrer-ChromeExtension/assets/4566555/f2f07cf8-b641-4816-805e-5620c74968f8)
 
 If the following patterns is set, the only `ab` is blurred because `ab` in the page is matched by the 1st keyword `ab` at first.  

--- a/docs/PRIORITY_OF_PATTERNS.md
+++ b/docs/PRIORITY_OF_PATTERNS.md
@@ -1,0 +1,27 @@
+# Priority of patterns
+
+The matching priority of keywords/patterns depends on the order of them (i.e. the keyword /pattern in the nth row is higher priority than the one in (n+1)th row). And each text is blurred only one time. a text already blurred is not target of pattern matching.
+
+## Example
+In this example, there is the text  `abc` in a web page. 
+![image](https://github.com/horihiro/TextBlurrer-ChromeExtension/assets/4566555/f2f07cf8-b641-4816-805e-5620c74968f8)
+
+If the following patterns is set, the only `ab` is blurred because `ab` in the page is matched by the 1st keyword `ab` at first.  
+The text `ab` is already blurred, so the whole text `abc` is not target of matching the pattern `abc`.
+
+```
+ab  
+abc
+```
+
+![image](https://github.com/horihiro/TextBlurrer-ChromeExtension/assets/4566555/6da21199-9b23-4477-bbd7-283b5ba66a2b)
+
+On the other hand, if the following patterns is set, the `abc` is blurred because `abc` in the page is matched by the 1st keyword `abc` .
+
+
+```
+abc  
+ab
+```
+
+![image](https://github.com/horihiro/TextBlurrer-ChromeExtension/assets/4566555/7bb80197-8d97-4368-a842-cf5428568c5b)

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Text Blurrer",
-  "version": "0.2.3",
-  "version_name": "0.2.3",
+  "version": "0.2.4",
+  "version_name": "0.2.4",
   "description": "Blurring sensitive specified text/keyword.",
   "permissions": [
     "storage",

--- a/popup/js/main.js
+++ b/popup/js/main.js
@@ -148,6 +148,9 @@ document.addEventListener('DOMContentLoaded', async (e) => {
         result.reason = 'Error:\n  This string might contain capture-group that should be non-capture-group.\n  Replace a pair of `(` and `)` to `(?:` and `)`.';
       } else if (/^(?:\.|(?:\\[^\\])|(?:\[[^\]]+\]))(?:\?|\*|\+|\{,?1\}|\{1,(?:\d+)?\})?$/.test(curr)) {
         result.reason = 'Warning:\n  One character matching might cause performance issue.';
+      } else if (curr !== '' && new RegExp(curr).test('')) {
+        result.isValid = false;
+        result.reason = 'Error:\n  This pattern matches an empty string.';
       }
       array.push(result);
       return array;


### PR DESCRIPTION
  - New features
    - Support `contentEditable`-enabled elements
  - Bug fixes
    - Fix tab title masking ([#65](https://github.com/horihiro/TextBlurrer-ChromeExtension/issues/65))
    - Fix issue with matching empty string ([#67](https://github.com/horihiro/TextBlurrer-ChromeExtension/issues/67))
  - Chores
    - Add documentation about priority of the keywords/patterns
